### PR TITLE
Property System Overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alum"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 authors = ["Ranjeeth Mahankali <ranjeethmahankali@gmail.com>"]
 description = "Halfedge based polygon mesh library."

--- a/src/check.rs
+++ b/src/check.rs
@@ -2,13 +2,13 @@ use crate::{
     element::Handle,
     iterator::HasIterators,
     topol::{HasTopology, Topology},
-    EPropRef, Error, FPropRef, HPropRef, Status, VPropRef,
+    EPropBuf, Error, FPropBuf, HPropBuf, Status, VPropBuf,
 };
 
 fn check_vertices(
     mesh: &Topology,
-    vstatus: &VPropRef<Status>,
-    hstatus: &HPropRef<Status>,
+    vstatus: &VPropBuf<Status>,
+    hstatus: &HPropBuf<Status>,
     hvisited: &mut [bool],
 ) -> Result<(), Error> {
     hvisited.fill(false);
@@ -49,10 +49,10 @@ fn check_vertices(
 
 fn check_edges(
     mesh: &Topology,
-    vstatus: &VPropRef<Status>,
-    hstatus: &HPropRef<Status>,
-    estatus: &EPropRef<Status>,
-    fstatus: &FPropRef<Status>,
+    vstatus: &VPropBuf<Status>,
+    hstatus: &HPropBuf<Status>,
+    estatus: &EPropBuf<Status>,
+    fstatus: &FPropBuf<Status>,
     hflags: &mut [bool],
 ) -> Result<(), Error> {
     for h in mesh.halfedges().filter(|h| !hstatus[*h].deleted()) {

--- a/src/decimate/mod.rs
+++ b/src/decimate/mod.rs
@@ -38,8 +38,8 @@ pub mod quadric;
 
 use crate::Queue;
 use crate::{
-    topol::Topology, Adaptor, EPropRef, EditableTopology, Error, HasIterators, PolyMeshT, Status,
-    VPropRefMut, HH, VH,
+    topol::Topology, Adaptor, EPropBuf, EditableTopology, Error, HasIterators, PolyMeshT, Status,
+    VPropBuf, HH, VH,
 };
 use std::cmp::Ordering;
 
@@ -119,8 +119,8 @@ where
 fn is_collapse_legal(
     mesh: &Topology,
     h: HH,
-    estatus: &EPropRef<Status>,
-    vstatus: &mut VPropRefMut<Status>,
+    estatus: &EPropBuf<Status>,
+    vstatus: &mut VPropBuf<Status>,
 ) -> bool {
     let v = h.tail(mesh);
     !vstatus[v].feature() // Vertex not a feature.

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -4,7 +4,7 @@ use crate::{
     iterator::HasIterators,
     status::Status,
     topol::Topology,
-    Adaptor, EPropRef, EPropRefMut, FPropRefMut, HPropRefMut, HasTopology, PolyMeshT, VPropRefMut,
+    Adaptor, EPropBuf, FPropBuf, HPropBuf, HasTopology, PolyMeshT, VPropBuf,
 };
 
 /// This trait defines functions to edit the topology of a mesh, with typical
@@ -20,8 +20,8 @@ pub trait EditableTopology: HasIterators {
     fn check_edge_collapse(
         &self,
         h: HH,
-        edge_status: &EPropRef<Status>,
-        vertex_status: &mut VPropRefMut<Status>,
+        edge_status: &EPropBuf<Status>,
+        vertex_status: &mut VPropBuf<Status>,
     ) -> bool {
         // Check if already deleted.
         if edge_status[h.edge()].deleted() {
@@ -141,9 +141,9 @@ pub trait EditableTopology: HasIterators {
     fn collapse_degenerate_triangle(
         &mut self,
         h: HH,
-        hstatus: &mut HPropRefMut<Status>,
-        estatus: &mut EPropRefMut<Status>,
-        fstatus: &mut FPropRefMut<Status>,
+        hstatus: &mut HPropBuf<Status>,
+        estatus: &mut EPropBuf<Status>,
+        fstatus: &mut FPropBuf<Status>,
     ) {
         let topol = self.topology_mut();
         let h1 = h.next(topol);
@@ -195,10 +195,10 @@ pub trait EditableTopology: HasIterators {
     fn collapse_edge(
         &mut self,
         h: HH,
-        vstatus: &mut VPropRefMut<Status>,
-        hstatus: &mut HPropRefMut<Status>,
-        estatus: &mut EPropRefMut<Status>,
-        fstatus: &mut FPropRefMut<Status>,
+        vstatus: &mut VPropBuf<Status>,
+        hstatus: &mut HPropBuf<Status>,
+        estatus: &mut EPropBuf<Status>,
+        fstatus: &mut FPropBuf<Status>,
         hcache: &mut Vec<HH>,
     ) {
         let topol = self.topology_mut();
@@ -604,9 +604,9 @@ pub trait EditableTopology: HasIterators {
     fn remove_edge(
         &mut self,
         e: EH,
-        hstatus: &mut HPropRefMut<Status>,
-        estatus: &mut EPropRefMut<Status>,
-        fstatus: &mut FPropRefMut<Status>,
+        hstatus: &mut HPropBuf<Status>,
+        estatus: &mut EPropBuf<Status>,
+        fstatus: &mut FPropBuf<Status>,
     ) -> Result<FH, Error> {
         //    <--------- <----------v0<---------- <----------
         //   |                n0    ^|     p1                ^

--- a/src/element.rs
+++ b/src/element.rs
@@ -7,7 +7,7 @@ use std::{
 
 /// All elements of the mesh implement this trait. They are identified by their
 /// index.
-pub trait Handle: From<u32> + Copy + Clone {
+pub trait Handle: From<u32> + Copy + Clone + 'static {
     /// The index of the element.
     fn index(&self) -> u32;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,8 @@ pub use mesh::{
     VectorAngleAdaptor, VectorLengthAdaptor, VectorNormalizeAdaptor,
 };
 pub use property::{
-    EPropRef, EPropRefMut, EProperty, FPropRef, FPropRefMut, FProperty, HPropRef, HPropRefMut,
-    HProperty, PropRef, PropRefMut, Property, VPropRef, VPropRefMut, VProperty,
+    EPropBuf, EProperty, FPropBuf, FProperty, HPropBuf, HProperty, PropBuf, Property, VPropBuf,
+    VProperty,
 };
 pub use queue::Queue;
 pub use status::Status;

--- a/src/math.rs
+++ b/src/math.rs
@@ -7,7 +7,7 @@ use crate::{
         VectorAngleAdaptor, VectorLengthAdaptor, VectorNormalizeAdaptor,
     },
     property::{FProperty, VProperty},
-    FPropRef, HasTopology, VPropRef,
+    FPropBuf, HasTopology, VPropBuf,
 };
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
@@ -34,7 +34,7 @@ where
     /// Calling this function in a hot loop with borrowed points property, can
     /// be faster than [`Self::try_calc_face_normal`] because it avoids repeated
     /// borrows.
-    pub fn calc_face_normal(&self, f: FH, points: &VPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_face_normal(&self, f: FH, points: &VPropBuf<A::Vector>) -> A::Vector {
         // Use newell's method to compute the normal.
         let (nverts, x, y, z) = {
             self.fh_ccw_iter(f).fold(
@@ -96,7 +96,7 @@ where
     /// of the vertices. Calling this function with borrowed `points` in a hot
     /// loop can be faster than [`Self::try_calc_vertex_normal_accurate`] by
     /// avoiding repeated borrows.
-    pub fn calc_vertex_normal_accurate(&self, v: VH, points: &VPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_vertex_normal_accurate(&self, v: VH, points: &VPropBuf<A::Vector>) -> A::Vector {
         A::normalized_vec(
             match v.halfedge(self) {
                 Some(h) => {
@@ -165,7 +165,7 @@ where
     /// Compute the centroid of a face as the average position of the incident vertices.
     ///
     /// `points` must be the positions of the vertices.
-    pub fn calc_face_centroid(&self, f: FH, points: &VPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_face_centroid(&self, f: FH, points: &VPropBuf<A::Vector>) -> A::Vector {
         let (denom, total) = self.fv_ccw_iter(f).fold(
             (A::scalarf64(0.0), A::zero_vector()),
             |(denom, total): (A::Scalar, A::Vector), v: VH| {
@@ -185,7 +185,7 @@ where
     /// Compute the vertex normal as the average of normals of incident
     /// faces. The normals of the incident faces are read from provided
     /// `fnormals`.
-    pub fn calc_vertex_normal_fast(&self, v: VH, fnormals: &FPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_vertex_normal_fast(&self, v: VH, fnormals: &FPropBuf<A::Vector>) -> A::Vector {
         A::normalized_vec(
             self.vf_ccw_iter(v)
                 .fold(A::zero_vector(), |total, f| total + fnormals[f]),
@@ -238,7 +238,7 @@ where
 
     /// Compute the vector spanning from the start of the halfedge to the head
     /// of the halfedge.
-    pub fn calc_halfedge_vector(&self, h: HH, points: &VPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_halfedge_vector(&self, h: HH, points: &VPropBuf<A::Vector>) -> A::Vector {
         points[h.head(self)] - points[h.tail(self)]
     }
 }
@@ -256,7 +256,7 @@ where
     /// previous halfedge. Calling this function in a hot loop with borrowed
     /// `points` can be faster than [`Self::try_calc_sector_normal`] by avoiding
     /// repeated borrows.
-    pub fn calc_sector_normal(&self, h: HH, points: &VPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_sector_normal(&self, h: HH, points: &VPropBuf<A::Vector>) -> A::Vector {
         A::cross_product(
             self.calc_halfedge_vector(h.prev(&self.topol), points),
             self.calc_halfedge_vector(h, points),
@@ -285,7 +285,7 @@ where
     /// previous halfedge. Calling this function in a hotloop with borrowed
     /// points can be faster than [`Self::try_calc_sector_area`] by avoiding
     /// repeated borrows.
-    pub fn calc_sector_area(&self, h: HH, points: &VPropRef<A::Vector>) -> A::Scalar {
+    pub fn calc_sector_area(&self, h: HH, points: &VPropBuf<A::Vector>) -> A::Scalar {
         A::vector_length(self.calc_sector_normal(h, points)) * A::scalarf64(0.5)
     }
 
@@ -303,7 +303,7 @@ where
     /// For non-planar polygonal faces, the computed area will be
     /// approximate. This is because the area is computed as the sum of
     /// triangles, present in the default triangulation of the face.
-    pub fn calc_face_area(&self, f: FH, points: &VPropRef<A::Vector>) -> A::Scalar {
+    pub fn calc_face_area(&self, f: FH, points: &VPropBuf<A::Vector>) -> A::Scalar {
         self.topol
             .triangulated_face_vertices(f)
             .fold(A::scalarf64(0.0), |total, vs| {
@@ -326,7 +326,7 @@ where
     /// Compute the total area of this mesh. `points` must be the positions of vertices.
     ///
     /// Calling this function with borrowed `points` property avoids an internal borrow.
-    pub fn calc_area(&self, points: &VPropRef<A::Vector>) -> A::Scalar {
+    pub fn calc_area(&self, points: &VPropBuf<A::Vector>) -> A::Scalar {
         self.faces().fold(A::scalarf64(0.0), |total, f| {
             total + self.calc_face_area(f, points)
         })
@@ -354,7 +354,7 @@ where
     A::Vector: Sub<Output = A::Vector>,
 {
     /// Compute the length of a mesh edge. `points` must be the positions of the vertices.
-    pub fn calc_edge_length(&self, e: EH, points: &VPropRef<A::Vector>) -> A::Scalar {
+    pub fn calc_edge_length(&self, e: EH, points: &VPropBuf<A::Vector>) -> A::Scalar {
         A::vector_length(self.calc_halfedge_vector(e.halfedge(false), points))
     }
 
@@ -390,7 +390,7 @@ where
 {
     /// Compute the squared length of a mesh edge. `points` must be the
     /// positions of the vertices.
-    pub fn calc_edge_length_sqr(&self, e: EH, points: &VPropRef<A::Vector>) -> A::Scalar {
+    pub fn calc_edge_length_sqr(&self, e: EH, points: &VPropBuf<A::Vector>) -> A::Scalar {
         let ev = self.calc_halfedge_vector(e.halfedge(false), points);
         A::dot_product(ev, ev)
     }
@@ -432,7 +432,7 @@ where
     ///
     /// Calling this function with borrowed `points` property avoids an internal
     /// borrow of properties.
-    pub fn calc_volume(&self, points: &VPropRef<A::Vector>) -> A::Scalar {
+    pub fn calc_volume(&self, points: &VPropBuf<A::Vector>) -> A::Scalar {
         if self.halfedges().any(|h| h.is_boundary(&self.topol)) {
             // Not closed.
             return A::scalarf64(0.0);
@@ -490,7 +490,7 @@ where
     /// The the sector normals of the halfedges are used to compute the dihedral
     /// angle. This can be more accurate than
     /// [`Self::calc_dihedral_angle_fast`].
-    pub fn calc_dihedral_angle(&self, e: EH, points: &VPropRef<A::Vector>) -> A::Scalar {
+    pub fn calc_dihedral_angle(&self, e: EH, points: &VPropBuf<A::Vector>) -> A::Scalar {
         if e.is_boundary(self) {
             return A::scalarf64(0.0);
         }
@@ -522,8 +522,8 @@ where
     pub fn calc_dihedral_angle_fast(
         &self,
         e: EH,
-        points: &VPropRef<A::Vector>,
-        face_normals: &FPropRef<A::Vector>,
+        points: &VPropBuf<A::Vector>,
+        face_normals: &FPropBuf<A::Vector>,
     ) -> A::Scalar {
         let h0 = e.halfedge(false);
         let h1 = e.halfedge(true);
@@ -568,8 +568,8 @@ where
     pub fn calc_sector_angle(
         &self,
         h: HH,
-        points: &VPropRef<A::Vector>,
-        face_normals: &FPropRef<A::Vector>,
+        points: &VPropBuf<A::Vector>,
+        face_normals: &FPropBuf<A::Vector>,
     ) -> A::Scalar {
         let n0 = self.calc_halfedge_vector(h, points);
         let h2 = h.prev(self).opposite();
@@ -605,7 +605,7 @@ where
     /// Compute the vertex centroid, i.e. the average position of all the vertices.
     ///
     /// `points` must be the positions of vertices.
-    pub fn calc_vertex_centroid(&self, points: &VPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_vertex_centroid(&self, points: &VPropBuf<A::Vector>) -> A::Vector {
         points.iter().fold(A::zero_vector(), |total, p| total + *p)
             / A::scalarf64(points.len() as f64)
     }
@@ -631,7 +631,7 @@ where
     /// Compute the area weighted centroid of the mesh.
     ///
     /// `points` must be the positions of vertices.
-    pub fn calc_area_centroid(&self, points: &VPropRef<A::Vector>) -> A::Vector {
+    pub fn calc_area_centroid(&self, points: &VPropBuf<A::Vector>) -> A::Vector {
         let (total, denom) = self.faces().fold(
             (A::zero_vector(), A::scalarf64(0.0)),
             |(total, denom), f| {
@@ -800,7 +800,7 @@ mod test {
         assert!(qbox.has_face_normals());
         let fnormals = fnormals.try_borrow().expect("Cannot borrow face normals");
         assert_eq!(
-            fnormals,
+            fnormals.as_ref(),
             &[
                 glam::vec3(0.0, 0.0, -1.0),
                 glam::vec3(0.0, -1.0, 0.0),

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -1,9 +1,9 @@
 use crate::{
     error::Error,
     mesh::{Adaptor, FloatScalarAdaptor, PolyMeshT},
-    Handle, HasIterators, HasTopology, VPropRef, VH,
+    Handle, HasIterators, HasTopology, VPropBuf, VH,
 };
-use std::{fmt::Display, fs::OpenOptions, io, path::Path};
+use std::{cell::Ref, fmt::Display, fs::OpenOptions, io, path::Path};
 
 impl<A> PolyMeshT<3, A>
 where
@@ -96,8 +96,8 @@ where
 
     fn write_obj_impl(
         &self,
-        points: VPropRef<A::Vector>,
-        vnormals: Option<VPropRef<A::Vector>>,
+        points: Ref<VPropBuf<A::Vector>>,
+        vnormals: Option<Ref<VPropBuf<A::Vector>>>,
         mut w: impl io::Write,
     ) -> Result<(), io::Error>
     where

--- a/src/subdiv/loop_subd.rs
+++ b/src/subdiv/loop_subd.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     topol::Topology, EditableTopology, Error, FloatScalarAdaptor, Handle, HasIterators,
-    HasTopology, PolyMeshT, VPropRef,
+    HasTopology, PolyMeshT, VPropBuf,
 };
 
 const WEIGHTS: [(f64, f64); 64] = [
@@ -120,7 +120,7 @@ where
 
     fn compute_vertex_points(
         mesh: &Topology,
-        points: &VPropRef<A::Vector>,
+        points: &VPropBuf<A::Vector>,
         dst: &mut Vec<A::Vector>,
     ) {
         dst.clear();
@@ -154,7 +154,7 @@ where
     fn compute_edge_points(
         mesh: &Topology,
         update_points: bool,
-        points: &VPropRef<A::Vector>,
+        points: &VPropBuf<A::Vector>,
         dst: &mut Vec<A::Vector>,
     ) {
         dst.clear();

--- a/src/subdiv/sqrt3.rs
+++ b/src/subdiv/sqrt3.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     topol::Topology, EditableTopology, Error, FloatScalarAdaptor, Handle, HasIterators,
-    HasTopology, PolyMeshT, VPropRef, EH,
+    HasTopology, PolyMeshT, VPropBuf, EH,
 };
 
 const WEIGHTS: [(f64, f64); 64] = [
@@ -102,7 +102,7 @@ where
     fn compute_edge_points(
         mesh: &Topology,
         e: EH,
-        points: &VPropRef<A::Vector>,
+        points: &VPropBuf<A::Vector>,
     ) -> (A::Vector, A::Vector) {
         let h = {
             let mut h = e.halfedge(false);


### PR DESCRIPTION
The API proved to be inconvenient to use in practice. It required repeated borrows of the properties instead of being able to use previous borrows. This fixes that.