### PR TITLE
Fix reserve

### DIFF
--- a/src/decimate/hausdorff.rs
+++ b/src/decimate/hausdorff.rs
@@ -1,0 +1,51 @@
+use super::Decimater;
+use crate::{Adaptor, Error, HasTopology, PolyMeshT, FH, HH, VH};
+
+pub struct HausdorffDecimater<A>
+where
+    A: Adaptor<3>,
+{
+    ptbuf: Vec<A::Vector>,
+    fpoints: Vec<Vec<A::Vector>>,
+    max_tol: A::Scalar,
+}
+
+impl<A> HausdorffDecimater<A>
+where
+    A: Adaptor<3>,
+{
+    pub fn new(mesh: &PolyMeshT<3, A>, max_tol: A::Scalar) -> Self {
+        HausdorffDecimater {
+            ptbuf: Vec::with_capacity(mesh.num_vertices()),
+            fpoints: vec![Vec::new(); mesh.num_faces()],
+            max_tol,
+        }
+    }
+}
+
+impl<A> Decimater<PolyMeshT<3, A>> for HausdorffDecimater<A>
+where
+    A: Adaptor<3>,
+    A::Scalar: PartialOrd,
+{
+    type Cost = A::Scalar;
+
+    fn collapse_cost(&self, mesh: &PolyMeshT<3, A>, h: HH) -> Option<Self::Cost> {
+        todo!()
+    }
+
+    fn before_collapse(&mut self, mesh: &PolyMeshT<3, A>, h: HH) -> Result<(), Error> {
+        Ok(()) // Nothing to do.
+    }
+
+    fn after_collapse(&mut self, mesh: &PolyMeshT<3, A>, v: VH) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+fn triangle_dist_sq<A>(p: &A::Vector, a: &A::Vector, b: &A::Vector, c: &A::Vector) -> A::Scalar
+where
+    A: Adaptor<3>,
+{
+    todo!("Implement point to triangle squared distance");
+}

--- a/src/decimate/mod.rs
+++ b/src/decimate/mod.rs
@@ -34,6 +34,7 @@ Out of the box, this module also provides the following implementations of
 */
 
 pub mod edge_length;
+pub mod hausdorff;
 pub mod quadric;
 
 use crate::Queue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,12 +148,12 @@ pub mod use_glam;
 mod subdiv;
 
 #[cfg(feature = "decimate")]
-pub mod decimate;
+mod decimate;
 
 #[cfg(feature = "decimate")]
 pub use decimate::{
-    edge_length::EdgeLengthDecimater, quadric::Quadric, quadric::QuadricDecimater,
-    quadric::QuadricType, Decimater, HasDecimation,
+    edge_length::EdgeLengthDecimater, hausdorff::HausdorffDecimater, quadric::Quadric,
+    quadric::QuadricDecimater, quadric::QuadricType, Decimater, HasDecimation,
 };
 
 pub use edit::EditableTopology;

--- a/src/property.rs
+++ b/src/property.rs
@@ -52,6 +52,9 @@ where
         self.props.push(prop);
     }
 
+    /**
+     * Reserve memory to accomodate an additional `n` elements.
+     */
     pub fn reserve(&mut self, n: usize) -> Result<(), Error> {
         for prop in self.props.iter_mut() {
             prop.reserve(n)?;
@@ -486,6 +489,9 @@ where
     T: Clone + Copy,
     H: Handle,
 {
+    /**
+     * Reserve memory for an additional `n` values.
+     */
     fn reserve(&mut self, n: usize) -> Result<(), Error> {
         if let Some(prop) = self.data.upgrade() {
             prop.try_borrow_mut()

--- a/src/subdiv/catmull.rs
+++ b/src/subdiv/catmull.rs
@@ -35,6 +35,11 @@ where
         edge_points: &mut Vec<A::Vector>,
         face_points: &mut Vec<A::Vector>,
     ) -> Result<(), Error> {
+        if let Some(vpts) = vertex_points {
+            vpts.clear();
+        }
+        edge_points.clear();
+        face_points.clear();
         debug_assert!(niter > 0);
         let mut nv = mesh.num_vertices();
         let mut ne = mesh.num_edges();

--- a/src/subdiv/loop_subd.rs
+++ b/src/subdiv/loop_subd.rs
@@ -105,6 +105,8 @@ where
         edge_points: &mut Vec<A::Vector>,
     ) -> Result<(), Error> {
         let (mut nv, mut ne, mut nf) = (mesh.num_vertices(), mesh.num_edges(), mesh.num_faces());
+        vertex_points.clear();
+        edge_points.clear();
         for i in 0..iterations {
             if i == iterations - 1 {
                 vertex_points.reserve(nv);

--- a/src/topol.rs
+++ b/src/topol.rs
@@ -197,7 +197,7 @@ pub trait HasTopology: Sized {
         self.topology().fprops.num_properties()
     }
 
-    /// Reserve memory for the given number of elements.
+    /// Reserve memory for the given number of `additional` elements.
     ///
     /// The memory is also reserved for all properties.
     fn reserve(&mut self, nverts: usize, nedges: usize, nfaces: usize) -> Result<(), Error> {


### PR DESCRIPTION
I recently learned that the `reserve` in Rust isn't the same as reserve in C++. I had used it incorrectly in a few places because of this misunderstanding. This fixes that.